### PR TITLE
fix:修复错误的标题配置

### DIFF
--- a/layout/_partial/header.ejs
+++ b/layout/_partial/header.ejs
@@ -5,9 +5,9 @@
       <h1 id="logo-wrap">
         <a href="<%- url_for('/') %>" id="logo"><%= config.title %></a>
       </h1>
-      <% if (theme.subtitle){ %>
+      <% if (config.subtitle) { %>
         <h2 id="subtitle-wrap">
-          <a href="<%- url_for('/') %>" id="subtitle"><%= theme.subtitle %></a>
+          <a href="<%- url_for('/') %>" id="subtitle"><%= config.subtitle %></a>
         </h2>
       <% } %>
     </div>

--- a/layout/_partial/left-col.ejs
+++ b/layout/_partial/left-col.ejs
@@ -8,10 +8,10 @@
 			<img src="<%- url_for(theme.avatar) %>" class="js-avatar">
 		</a>
 		<hgroup>
-			<h1 class="header-author"><a href="<%- url_for('/') %>"><%=theme.author%></a></h1>
+			<h1 class="header-author"><a href="<%- url_for('/') %>"><%= config.author %></a></h1>
 		</hgroup>
-		<% if (theme.subtitle){ %>
-		<p class="header-subtitle"><%=theme.subtitle%></p>
+		<% if (config.subtitle) { %>
+		<p class="header-subtitle"><%= config.subtitle %></p>
 		<%}%>
 
 		<nav class="header-menu">

--- a/layout/_partial/mobile-nav.ejs
+++ b/layout/_partial/mobile-nav.ejs
@@ -12,10 +12,10 @@
 				</a>
 			</div>
 			<hgroup>
-			  <h1 class="header-author js-header-author"><%=theme.author%></h1>
+			  <h1 class="header-author js-header-author"><%= config.author %></h1>
 			</hgroup>
-			<% if (theme.subtitle){ %>
-			<p class="header-subtitle"><i class="icon icon-quo-left"></i><%=theme.subtitle%><i class="icon icon-quo-right"></i></p>
+			<% if (config.subtitle) { %>
+			<p class="header-subtitle"><i class="icon icon-quo-left"></i><%= config.subtitle %><i class="icon icon-quo-right"></i></p>
 			<% } %>
 			<% var count = 0; %>
 			<% for (var i in theme.menu){ %>


### PR DESCRIPTION
<!--
Thank you for creating a pull request to contribute to Yilia-plus code! Before you open the request please answer the following questions to help it be more easily integrated. Please check the boxes "[ ]" with "[x]" when done too.
-->

## Description
修复错误的标题配置
像 `title`, `subtitle`, `author` 等配置应在 `config` 中，而不是 `theme` 中，theme 的 config.yml 中没有这些字段
修复nav中不显示标题和子标题的问题

## Specific Changes proposed
Change `theme` to `config` in 3 files

## How to test

```bash
hexo server
```

## Screenshots



## Pull request tasks

- [x] Add test cases for the changes.
- [x] Passed the CI test.
